### PR TITLE
general (working) OOD link

### DIFF
--- a/docs/source/user_guide/accessing.rst
+++ b/docs/source/user_guide/accessing.rst
@@ -59,6 +59,8 @@ For command line SSH clients, use the following settings if you have trouble log
 Open OnDemand
 -------------
 
+The general Open OnDemand interface to Delta is here: https://openondemand.delta.ncsa.illinois.edu/.  
+
 An Open OnDemand shell interface is available at: https://openondemand.delta.ncsa.illinois.edu/pun/sys/shell/ssh/dt-login02.
 
 ..  image:: images/accessing/ood-shell-access.png


### PR DESCRIPTION
There's a "get an Open OnDemand terminal" link that at least for me, doesn't work on Chrome.  There's no other OOD mention in this section. 

I'm adding a link that I believe is the right one to the general OOD interface.  I'll track down if the terminal link is still useful or not.

I'll confer with others in the project to get this section up to date and tested before we merge the branch.  

@kc9qey  ?