### PR TITLE
OOD fixes

### DIFF
--- a/docs/source/user_guide/accessing.rst
+++ b/docs/source/user_guide/accessing.rst
@@ -59,10 +59,12 @@ For command line SSH clients, use the following settings if you have trouble log
 Open OnDemand
 -------------
 
-An Open OnDemand shell interface is available at: https://openondemand.delta.ncsa.illinois.edu/pun/sys/shell/ssh/dt-login02.
+The general Open OnDemand interface to Delta is here: https://openondemand.delta.ncsa.illinois.edu/.
 
-..  image:: images/accessing/ood-shell-access.png
-    :alt: Delta OpenOnDemand shell access
+An Open OnDemand shell interface is available at: https://openondemand.delta.ncsa.illinois.edu/pun/sys/shell/ssh/dt-login.
+
+..  image:: images/accessing/Delta_OOD_terminal.png
+    :alt: Black terminal with a command prompt that ends in "csteffen@dt-login's password:"
 
 VS Code
 -------


### PR DESCRIPTION
Three fixes in the Open OnDemand section.  

1) Adding the general link.  2) Fixing the terminal link.  3) swapping out the screenshot for one that actually refers to Delta and is a login to delta.