### PR TITLE
Update software.rst

### DIFF
--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -10,11 +10,18 @@ An automated list of available software can be found on the ACCESS website.
 Modules/Lmod
 -----------------
 
+  .. tab:: Slingshot10
+
 Delta provides two sets of modules and a variety of compilers in each set. 
 The default environment is **modtree/gpu** which loads a recent version of GNU compilers, the Open MPI implementation of MPI, and CUDA.
 The environment with GPU support will build binaries that run on both the GPU nodes (with CUDA) and CPU nodes (potentially with warning messages because those nodes lack CUDA drivers). 
 For situations where the same version of software is to be deployed on GPU and CPU nodes but with separate builds, the **modtree/cpu** environment provides the same default compiler and MPI but without CUDA. 
 Use module spider package_name to search for software in Lmod and see the steps to load it for your environment.
+
+  .. tab:: Slingshot11
+
+Delta provides a set of modules and a variety of compilers.  The default environment loads gcc and openmpi for cpu programs (no GPU-direct).
+Modules supporting Nvidia GPUs will contain "cuda" in the name of the module, Ex: openmpi/4.1.5+cuda .  Unload cuda when building cpu-only packages to avoid accidentally linking cuda libraries.  Use module spider package_name to search for software in Lmod and see the steps to load it in your environment.
 
 .. table:: Module (Lmod) Commands
 

--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -18,12 +18,12 @@ Modules/Lmod
       The default environment is **modtree/gpu** which loads a recent version of GNU compilers, the Open MPI implementation of MPI, and CUDA.
       The environment with GPU support will build binaries that run on both the GPU nodes (with CUDA) and CPU nodes (potentially with warning messages because those nodes lack CUDA drivers). 
       For situations where the same version of software is to be deployed on GPU and CPU nodes but with separate builds, the **modtree/cpu** environment provides the same default compiler and MPI but without CUDA. 
-      Use module spider package_name to search for software in Lmod and see the steps to load it for your environment.
+      Use ``module spider package_name`` to search for software in Lmod and see the steps to load it for your environment.
 
    .. tab:: Slingshot11
 
-      Delta provides a set of modules and a variety of compilers.  The default environment loads gcc and openmpi for cpu programs (no GPU-direct).
-      Modules supporting Nvidia GPUs will contain "cuda" in the name of the module, Ex: openmpi/4.1.5+cuda .  Unload cuda when building cpu-only packages to avoid accidentally linking cuda libraries.  Use module spider package_name to search for software in Lmod and see the steps to load it in your environment.
+      Delta provides a set of modules and a variety of compilers. The default environment loads gcc and openmpi for CPU programs (no GPU-direct).
+      Modules supporting NVIDIA GPUs will contain "cuda" in the name of the module, for example, openmpi/4.1.5+cuda.  Unload cuda when building CPU-only packages to avoid accidentally linking cuda libraries.  Use ``module spider package_name`` to search for software in Lmod and see the steps to load it in your environment.
 
 .. table:: Module (Lmod) Commands
 

--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -10,18 +10,20 @@ An automated list of available software can be found on the ACCESS website.
 Modules/Lmod
 -----------------
 
-  .. tab:: Slingshot10
+.. tabs::
 
-Delta provides two sets of modules and a variety of compilers in each set. 
-The default environment is **modtree/gpu** which loads a recent version of GNU compilers, the Open MPI implementation of MPI, and CUDA.
-The environment with GPU support will build binaries that run on both the GPU nodes (with CUDA) and CPU nodes (potentially with warning messages because those nodes lack CUDA drivers). 
-For situations where the same version of software is to be deployed on GPU and CPU nodes but with separate builds, the **modtree/cpu** environment provides the same default compiler and MPI but without CUDA. 
-Use module spider package_name to search for software in Lmod and see the steps to load it for your environment.
+   .. tab:: Slingshot10
 
-  .. tab:: Slingshot11
+      Delta provides two sets of modules and a variety of compilers in each set. 
+      The default environment is **modtree/gpu** which loads a recent version of GNU compilers, the Open MPI implementation of MPI, and CUDA.
+      The environment with GPU support will build binaries that run on both the GPU nodes (with CUDA) and CPU nodes (potentially with warning messages because those nodes lack CUDA drivers). 
+      For situations where the same version of software is to be deployed on GPU and CPU nodes but with separate builds, the **modtree/cpu** environment provides the same default compiler and MPI but without CUDA. 
+      Use module spider package_name to search for software in Lmod and see the steps to load it for your environment.
 
-Delta provides a set of modules and a variety of compilers.  The default environment loads gcc and openmpi for cpu programs (no GPU-direct).
-Modules supporting Nvidia GPUs will contain "cuda" in the name of the module, Ex: openmpi/4.1.5+cuda .  Unload cuda when building cpu-only packages to avoid accidentally linking cuda libraries.  Use module spider package_name to search for software in Lmod and see the steps to load it in your environment.
+   .. tab:: Slingshot11
+
+      Delta provides a set of modules and a variety of compilers.  The default environment loads gcc and openmpi for cpu programs (no GPU-direct).
+      Modules supporting Nvidia GPUs will contain "cuda" in the name of the module, Ex: openmpi/4.1.5+cuda .  Unload cuda when building cpu-only packages to avoid accidentally linking cuda libraries.  Use module spider package_name to search for software in Lmod and see the steps to load it in your environment.
 
 .. table:: Module (Lmod) Commands
 


### PR DESCRIPTION
added tab for the lmod description since s11 side is not using 2 modtrees...it's a single set of modules and "cuda" is in the names of gpu variants of modules where appropriate.