### PR TITLE
Fixing a couple of links and removing outdated info on preemptive jobs

### DIFF
--- a/docs/source/user_guide/accounts.rst
+++ b/docs/source/user_guide/accounts.rst
@@ -47,5 +47,5 @@ Allocation Supplements and Extensions
 
 Request resource allocation supplements (compute, GPU, or storage) and extensions via the appropriate XRAS website.
 
-- ACCESS allocation PIs can find instructions on the `ACCESS Managing allocations <https://allocations.access-ci.org/manage-allocations-overview#h.ii1cvqx8falk>`_ page.
+- ACCESS allocation PIs can find instructions on the `ACCESS Allocations: How To <https://allocations.access-ci.org/how-to>`_ page.
 - NCSA allocation PIs can find instructions on the `Delta Allocations <https://wiki.ncsa.illinois.edu/display/USSPPRT/Delta+Allocations#DeltaAllocations-Requestingan%22Extension%22or%22Supplement%22foranexistingDeltaallocation>`_ page.

--- a/docs/source/user_guide/data_mgmt.rst
+++ b/docs/source/user_guide/data_mgmt.rst
@@ -64,7 +64,7 @@ To transfer files to and from the Delta system:
 
 -  Globus - Use it for large data transfers.
 
-   - **Upgrade your Globus Connect Personal** to at least version 3.2.0 before Dec 12, 2022. See: https://docs.globus.org/ca-update-2022/#notice.
+   - `Upgrade your Globus Connect Personal to at least version 3.2.0 <https://docs.globus.org/ca-update-2022/#notice>`_
 
    -  Use the Delta collection "**NCSA Delta**" (see screen capture below).
       
@@ -72,7 +72,7 @@ To transfer files to and from the Delta system:
           :alt: Globus on Delta
           :width: 700px
 
-   -  See the following documentation on using Globus: https://docs.globus.org/how-to/get-started/ .
+   -  If you're new to Globus, review the `How To Log In and Transfer Files with Globus <https://docs.globus.org/guides/tutorials/manage-files/transfer-files/>`_ page for instructions on getting started.
 
 Infinite Memory Engine (IME)
 -----------------------------------

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -131,8 +131,6 @@ Node-exclusive mode can be obtained by specifying all the consumable resources f
 
 GPU NVIDIA MIG (GPU slicing) for the A100 will be supported at a future date.
 
-Pre-emptive jobs will be supported at a future date.
-
 Job Policies
 ----------------
 

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -44,9 +44,9 @@ See also, :ref:`mon_node`.
 Scheduler
 -------------
 
-For information, see the `Slurm quick reference guide <https://slurm.schedmd.com/quickstart.html>`_.
+For information, see the `Slurm quick start user guide <https://slurm.schedmd.com/quickstart.html>`_.
 
-..  image:: images/running_jobs/slurm_summary.pdf
+..  figure:: images/running_jobs/slurm_summary.pdf
     :alt: Slurm quick reference guide
     :width: 500
 


### PR DESCRIPTION
Updated a few hyperlinks to fix a broken target and updated descriptive link text.

Removed "Pre-emptive jobs will be supported at a future date." from Node Policies section (Running Jobs). Preempt queues are now available. Preempt section is two below Node Policies.

Built in Read the Docs: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/index.html