### PR TITLE
New job dependency delay section

### DIFF
--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -131,8 +131,6 @@ Node-exclusive mode can be obtained by specifying all the consumable resources f
 
 GPU NVIDIA MIG (GPU slicing) for the A100 will be supported at a future date.
 
-Pre-emptive jobs will be supported at a future date.
-
 Job Policies
 ----------------
 

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -44,9 +44,9 @@ See also, :ref:`mon_node`.
 Scheduler
 -------------
 
-For information, see the `Slurm quick reference guide <https://slurm.schedmd.com/quickstart.html>`_.
+For information, see the `Slurm quick start user guide <https://slurm.schedmd.com/quickstart.html>`_.
 
-..  image:: images/running_jobs/slurm_summary.pdf
+..  figure:: images/running_jobs/slurm_summary.pdf
     :alt: Slurm quick reference guide
     :width: 500
 

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -431,7 +431,7 @@ See the sbatch man page for additional environment variables available.
 Using Job Dependency to Stagger Job Starts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When submitting multiple jobs, consider using ``--dependency`` to prevent all of the jobs from starting at the same time. Staggering the job startup resource load, prevents system slowdowns. This is especially recommended for Python users because **multiple jobs that load Python on startup can slow down the system if they are all started at the same time**.
+When submitting multiple jobs, consider using ``--dependency`` to prevent all of the jobs from starting at the same time. Staggering the job startup resource load prevents system slowdowns. This is especially recommended for Python users because **multiple jobs that load Python on startup can slow down the system if they are all started at the same time**.
 
 From the ``--dependency`` man page:
 


### PR DESCRIPTION
New section in Running Jobs -> Job Management that shows users how to use --dependency to delay starts of multiple jobs. Includes example script that users can use/modify to automate/loop time delay on multiple jobs.

Built in Read the Docs: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/user_guide/running_jobs.html#using-job-dependency-to-stagger-job-starts

This is based on Issue #9 (Jira ticket DELTA-2332).