### PR TITLE
2 New FAQs and 'module purge' updates in example code

### DIFF
--- a/docs/source/aux_pages/migrate.txt
+++ b/docs/source/aux_pages/migrate.txt
@@ -2993,8 +2993,7 @@ A sample batch script for pytorch resembles:
    ##SBATCH --gpus-per-task=1
    ##SBATCH --gpu-bind=none     # <- or closest
 
-   module purge # drop modules and explicitly load the ones needed
-                # (good job metadata and reproducibility)
+   module reset 
 
    module list  # job documentation and metadata
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -38,3 +38,5 @@ Why doesn't nvidia-smi find a GPU?
 ------------------------------------
 
 You are running the command on a CPU-only compute node or on one of the login nodes. Only the GPU nodes contain NVIDIA GPUs, and they are accessible via the Slurm batch system. See :ref:`running-jobs`.
+
+|

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -33,3 +33,7 @@ This can result from bringing software onto Delta that was not built on the syst
 .. code-block:: terminal
 
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBRARY_PATH
+
+Why does nvidia-smi not find a gpu?
+------------------------------------
+You are running the command on a cpu-only compute node OR on one of the login nodes.  Only the gpu nodes contain Nvidia gpus and they are accessible via the slurm batch system.  See: `Running Jobs <https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html/>`_

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -25,11 +25,11 @@ How do I acknowledge Delta, NCSA, and/or ACCESS in my research?
 
 See `Delta Citations <https://delta.ncsa.illinois.edu/delta-citations/>`_ for information on how to acknwoledge Delta or NCSA, and `Acknowledging ACCESS <https://access-ci.org/about/acknowledging-access/>`_ for information on how to acknowledge ACCESS.
 
-Programming and jobs related questions:
-========================================
+What causes "ImportError: /lib64/libstdc++.so.6: version GLIBCXX_3.x.x not found"?
+-------------------------------------------------------------------------------------
 
-What causes "ImportError: /lib64/libstdc++.so.6: version GLIBCXX_3.x.x not found" ?
-------------------------------------------------------------------------------------
+This can result from bringing software onto Delta that was not built on the system using the system programming modules.  You can usually work around this by setting: 
 
-This can result from bringing software onto Delta that was not built on the system using the system programming modules.  You can usually work around this by setting:  
+.. code-block:: terminal
+
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBRARY_PATH

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -34,6 +34,7 @@ This can result from bringing software onto Delta that was not built on the syst
 
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBRARY_PATH
 
-Why does nvidia-smi not find a gpu?
+Why doesn't nvidia-smi find a GPU?
 ------------------------------------
-You are running the command on a cpu-only compute node OR on one of the login nodes.  Only the gpu nodes contain Nvidia gpus and they are accessible via the slurm batch system.  See: `Running Jobs <https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html/>`_
+
+You are running the command on a CPU-only compute node or on one of the login nodes. Only the GPU nodes contain NVIDIA GPUs and they are accessible via the Slurm batch system. See :ref:`running-jobs`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -23,7 +23,7 @@ If you can’t find the answer in the documentation (or via the search bar in th
 How do I acknowledge Delta, NCSA, and/or ACCESS in my research?
 ------------------------------------------------------------------
 
-See `Delta Citations <https://delta.ncsa.illinois.edu/delta-citations/>`_ for information on how to acknwoledge Delta or NCSA, and `Acknowledging ACCESS <https://access-ci.org/about/acknowledging-access/>`_ for information on how to acknowledge ACCESS.
+See `Delta Citations <https://delta.ncsa.illinois.edu/delta-citations/>`_ for information on how to acknowledge Delta or NCSA, and `Acknowledging ACCESS <https://access-ci.org/about/acknowledging-access/>`_ for information on how to acknowledge ACCESS.
 
 What causes "ImportError: /lib64/libstdc++.so.6: version GLIBCXX_3.x.x not found"?
 -------------------------------------------------------------------------------------
@@ -37,4 +37,4 @@ This can result from bringing software onto Delta that was not built on the syst
 Why doesn't nvidia-smi find a GPU?
 ------------------------------------
 
-You are running the command on a CPU-only compute node or on one of the login nodes. Only the GPU nodes contain NVIDIA GPUs and they are accessible via the Slurm batch system. See :ref:`running-jobs`.
+You are running the command on a CPU-only compute node or on one of the login nodes. Only the GPU nodes contain NVIDIA GPUs, and they are accessible via the Slurm batch system. See :ref:`running-jobs`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -25,4 +25,11 @@ How do I acknowledge Delta, NCSA, and/or ACCESS in my research?
 
 See `Delta Citations <https://delta.ncsa.illinois.edu/delta-citations/>`_ for information on how to acknwoledge Delta or NCSA, and `Acknowledging ACCESS <https://access-ci.org/about/acknowledging-access/>`_ for information on how to acknowledge ACCESS.
 
-|
+Programming and jobs related questions:
+========================================
+
+What causes "ImportError: /lib64/libstdc++.so.6: version GLIBCXX_3.x.x not found" ?
+------------------------------------------------------------------------------------
+
+This can result from bringing software onto Delta that was not built on the system using the system programming modules.  You can usually work around this by setting:  
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBRARY_PATH

--- a/docs/source/user_guide/containers.rst
+++ b/docs/source/user_guide/containers.rst
@@ -191,6 +191,7 @@ Sample Batch Script for PyTorch
    ##SBATCH --gpus-per-task=1
    ##SBATCH --gpu-bind=none    # <- or closest
 
+   # reminder here, containers are not using or consulting any loaded modules
    module purge # drop modules and explicitly load the ones needed
                 # (good job metadata and reproducibility)
 

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -728,6 +728,8 @@ Serial Jobs on CPU Nodes
    #SBATCH --job-name=myjobtest
    #SBATCH --time=00:10:00      # hh:mm:ss for the job
    #SBATCH --constraint="scratch"
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
    ### GPU options ###
    ##SBATCH --gpus-per-node=2
    ##SBATCH --gpu-bind=none     # <- or closest
@@ -768,6 +770,8 @@ MPI on CPU Nodes
    #SBATCH --job-name=mympi
    #SBATCH --time=00:10:00      # hh:mm:ss for the job
    #SBATCH --constraint="scratch"
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
    ### GPU options ###
    ##SBATCH --gpus-per-node=2
    ##SBATCH --gpu-bind=none     # <- or closest ##SBATCH --mail-user=you@yourinstitution.edu
@@ -806,6 +810,8 @@ OpenMP on CPU Nodes
    #SBATCH --job-name=myopenmp
    #SBATCH --time=00:10:00      # hh:mm:ss for the job
    #SBATCH --constraint="scratch"
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
    ### GPU options ###
    ##SBATCH --gpus-per-node=2
    ##SBATCH --gpu-bind=none     # <- or closest
@@ -846,6 +852,8 @@ Hybrid (MPI + OpenMP or MPI+X) on CPU Nodes
    #SBATCH --job-name=mympi+x
    #SBATCH --time=00:10:00      # hh:mm:ss for the job
    #SBATCH --constraint="scratch"
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
    ### GPU options ###
    ##SBATCH --gpus-per-node=2
    ##SBATCH --gpu-bind=none     # <- or closest
@@ -891,6 +899,8 @@ Hybrid (MPI + OpenMP or MPI+X) on CPU Nodes
    #SBATCH --exclusive  # dedicated node for this job
    #SBATCH --no-requeue
    #SBATCH -t 04:00:00
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
 
    export OMP_NUM_THREADS=1  # if code is not multithreaded, otherwise set to 8 or 16
    srun -N 1 -n 4 ./a.out > myjob.out
@@ -927,6 +937,8 @@ Hybrid (MPI + OpenMP or MPI+X) on CPU Nodes
    #SBATCH --exclusive  # dedicated node for this job
    #SBATCH --no-requeue
    #SBATCH -t 04:00:00
+   #SBATCH -e slurm-%j.err
+   #SBATCH -o slurm-%j.out
 
    export OMP_NUM_THREADS=1  # if code is not multithreaded, otherwise set to 8 or 16
    srun -N 1 -n 4 ./a.out > myjob.out

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -1,3 +1,5 @@
+.. _running-jobs:
+
 Running Jobs
 ===============
 

--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -723,8 +723,9 @@ A sample TensorFlow test script:
    #SBATCH --gpu-bind=verbose,per_task:1
    ###SBATCH --gpu-bind=none     # <- or closest
 
-   module purge # drop modules and explicitly load the ones needed
-                # (good job metadata and reproducibility)
+   # expert mode only, most users will not purge all modules
+   # module purge # drop modules and explicitly load the ones needed, including cuda
+                  # (good job metadata and reproducibility)
 
    module load anaconda3_gpu
    module list  # job documentation and metadata


### PR DESCRIPTION
Adds 2 new FAQs:
1. “ImportError: /lib64/libstdc++.so.6: version GLIBCXX_3.x.x not found”
2. nvidia-smi not finding a GPU

Also updates a couple of code examples to address ``module purge`` issue (see Issue #112 ).

RTD build: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/

