### PR TITLE
Updated home quota 

### DIFF
--- a/docs/source/fake.txt
+++ b/docs/source/fake.txt
@@ -1,0 +1,1 @@
+fake file to generate a commit.  

--- a/docs/source/fake.txt
+++ b/docs/source/fake.txt
@@ -1,1 +1,0 @@
-fake file to generate a commit.  

--- a/docs/source/user_guide/architecture.rst
+++ b/docs/source/user_guide/architecture.rst
@@ -411,7 +411,7 @@ DDN SFA18XE (Quantity: 1), each unit contains:
    +---------------+-------------------------------------+---------------+---------------+--------------------------------------------+
    | File System   | Quota                               | Snapshots     | Purged        | Key Features                               |
    +===============+=====================================+===============+===============+============================================+
-   | HOME (/u)     | **50 GB.** 600,000 files per user.  | No/TBA        | No            | Area for software, scripts, job files, and |
+   | HOME (/u)     | **90 GB.** 600,000 files per user.  | No/TBA        | No            | Area for software, scripts, job files, and |
    |               |                                     |               |               |                                            |
    |               |                                     |               |               | so on. **Not** intended as a               |
    |               |                                     |               |               |                                            |


### PR DESCRIPTION
Updated home quota in File System Specs table from 50GB to 90GB, per G. Bauer

RTD build: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/user_guide/architecture.html#id13