### PR TITLE
Update to Allocation Supplements and Extensions

### DIFF
--- a/docs/source/user_guide/accounts.rst
+++ b/docs/source/user_guide/accounts.rst
@@ -41,7 +41,14 @@ There is a 30-day grace period for expired Delta projects to allow for data mana
 Allocation Supplements and Extensions
 ---------------------------------------
 
-Request resource allocation supplements (compute, GPU, or storage) and extensions via the appropriate XRAS website.
+Request resource allocation supplements (CPU or GPU compute) and date extensions via the appropriate XRAS website:
 
 - ACCESS allocation PIs can find instructions on the `ACCESS Allocations: How To <https://allocations.access-ci.org/how-to>`_ page.
 - NCSA allocation PIs can find instructions on the `Delta Allocations <https://wiki.ncsa.illinois.edu/display/USSPPRT/Delta+Allocations#DeltaAllocations-Requestingan%22Extension%22or%22Supplement%22foranexistingDeltaallocation>`_ page.
+
+For storage quota increases, send an email to help@ncsa.illinois.edu with the quota increase request.
+
+- In the email, include a detailed justification for the size of the request and the duration of the need.
+- Keep in mind that Delta is storage constrained and can only provide storage for data in active use by computations on the system.
+
+|

--- a/docs/source/user_guide/accounts.rst
+++ b/docs/source/user_guide/accounts.rst
@@ -46,9 +46,13 @@ Request resource allocation supplements (CPU or GPU compute) and date extensions
 - ACCESS allocation PIs can find instructions on the `ACCESS Allocations: How To <https://allocations.access-ci.org/how-to>`_ page.
 - NCSA allocation PIs can find instructions on the `Delta Allocations <https://wiki.ncsa.illinois.edu/display/USSPPRT/Delta+Allocations#DeltaAllocations-Requestingan%22Extension%22or%22Supplement%22foranexistingDeltaallocation>`_ page.
 
-For storage quota increases, send an email to help@ncsa.illinois.edu with the quota increase request.
+.. raw:: html
+   
+   <p>To request a storage quota increase, send an email to <a href="mailto:help@ncsa.illinois.edu?subject=Delta: Quota Increase Request ">help@ncsa.illinois.edu</a> to initiate a ticket. In the email include:</p>
 
-- In the email, include a detailed justification for the size of the request and the duration of the need.
-- Keep in mind that Delta is storage constrained and can only provide storage for data in active use by computations on the system.
+- A detailed justification for the size of the increase.
+- How long you need the increase.
+
+Keep in mind that Delta is storage constrained and can only provide storage for data in active use by computations on the system.
 
 |


### PR DESCRIPTION
Added info about storage quota increase requests to Allocation Supplements and Extensions on the /accounts page. This was requested in issue #127 