### PR TITLE
Updated 'Getting Help' to add info on new JSM Help Center

### DIFF
--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -26,10 +26,10 @@ When you submit a support request, please let us know what you tried, and what h
 
 .. _general_support:
 
-NCSA Support Help Center - General Resource Support
+General Resource Support - NCSA Support Help Center 
 -----------------------------------------------------
 
-For all other issues, regardless of allocation type, use the `NCSA Support Help Center <http://help.ncsa.illinois.edu>`_. Powered by Jira Service Manager (JSM), in this new tool you can:
+Use the `NCSA Support Help Center <http://help.ncsa.illinois.edu>`_ for all other issues, regardless of allocation type. Powered by Jira Service Manager (JSM), in this new tool you can:
 
 - Search knowledge base articles to resolve common issues faster.
 - Submit help request tickets.

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -22,14 +22,33 @@ System users can often fix problems or help diagnose them on their own. The foll
 - If you're getting an error, perform a web search of the error message (Google, Bing, or others).
 - If you're looking for a package, perform a web search for "how do I install <package name>" and try the solutions you find that seem applicable and reasonable.  
 
-When you submit a support request, please let us know what you tried, and what happened if it didn't seem to work.  
+When you submit a support request, please let us know what you tried, and what happened if it didn't seem to work.
 
-General Resource Support
----------------------------
+.. _general_support:
+
+NCSA Support Help Center - General Resource Support
+-----------------------------------------------------
+
+For all other issues, regardless of allocation type, use the `NCSA Support Help Center <http://help.ncsa.illinois.edu>`_. Powered by Jira Service Manager (JSM), in this new tool you can:
+
+- Search knowledge base articles to resolve common issues faster.
+- Submit help request tickets.
+- Monitor the status of your tickets.
+- Respond to NCSA staff as they work to resolve your tickets.
+
+Refer to the `JSM User Job Aid <_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the new help center.
 
 .. raw:: html
    
-   <p>For <b>all other issues</b>, regardless of allocation type, please <b>submit a support request</b> by emailing <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a>. Your email will initiate a ticket that NCSA staff will use to help you.</p>
+   <p>The NCSA Help Center is the preferred method to submit requests, however, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
+
+Email Support Request Guidelines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. raw:: html
+
+   <details>
+   <summary><a><b>Email support request guidelines</b> <i>(click to expand/collapse)</i></a></summary>
 
 **To help NCSA staff efficiently address your request, in your initial email, please include:**
 
@@ -51,5 +70,9 @@ General Resource Support
 **If you have multiple, unrelated issues, please create a separate ticket for each by sending separate emails.**
 
 You will receive email correspondence as your ticket is worked on, please respond to any questions that are asked.
+
+.. raw:: html
+
+   </details>
 
 |

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -36,7 +36,7 @@ For all other issues, regardless of allocation type, use the `NCSA Support Help 
 - Monitor the status of your tickets.
 - Respond to NCSA staff as they work to resolve your tickets.
 
-Refer to the `JSM User Job Aid <_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the help center.
+Refer to the `JSM User Job Aid <https://docs.ncsa.illinois.edu/en/latest/_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the help center.
 
 .. raw:: html
    

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -36,11 +36,11 @@ For all other issues, regardless of allocation type, use the `NCSA Support Help 
 - Monitor the status of your tickets.
 - Respond to NCSA staff as they work to resolve your tickets.
 
-Refer to the `JSM User Job Aid <_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the new help center.
+Refer to the `JSM User Job Aid <_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the help center.
 
 .. raw:: html
    
-   <p>The NCSA Help Center is the preferred method to submit requests, however, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
+   <p>The <a href="http://help.ncsa.illinois.edu">NCSA Support Help Center</a> is the preferred method to submit requests. However, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
 
 Email Support Request Guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updated the 'General Support' section of 'Getting Help' to point to the new JSM Help Center. Kept info about email as option if users have issue using the help center but the help center is clearly described as the preferred method.

RTD build: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/help.html#ncsa-support-help-center-general-resource-support