### PR TITLE
More 'help' updates for the new JSM tool

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -15,11 +15,6 @@ Most Delta compute resource allocations are awarded through the ACCESS program.
 
 See the `Delta Allocations <https://delta.ncsa.illinois.edu/delta-allocations/>`_ page to learn more about the different allocation methods and how to submit an allocation request to each.
 
-How do I get help if I can’t find the answer in the documentation?
----------------------------------------------------------------------
-
-If you can’t find the answer in the documentation (or via the search bar in the upper left corner), :ref:`submit a support request <help>`. The ticket that is initiated becomes a discussion of your problem and the path to a solution.
-
 How do I acknowledge Delta, NCSA, and/or ACCESS in my research?
 ------------------------------------------------------------------
 

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -19,6 +19,9 @@ Explore Solutions
 System users can often fix problems or help diagnose them on their own. The following are some strategies to try before you submit a support request:
 
 - Search the documentation for relevant keywords; use the search box in the upper left.
+
+  Also try the search box on the `NCSA Documentation Hub <https://docs.ncsa.illinois.edu/>`_; this will return keyword results from *all* of the NCSA user documentation sets.
+
 - If you're getting an error, perform a web search of the error message (Google, Bing, or others).
 - If you're looking for a package, perform a web search for "how do I install <package name>" and try the solutions you find that seem applicable and reasonable.  
 

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -19,7 +19,6 @@ Explore Solutions
 System users can often fix problems or help diagnose them on their own. The following are some strategies to try before you submit a support request:
 
 - Search the documentation for relevant keywords; use the search box in the upper left.
-
   Also try the search box on the `NCSA Documentation Hub <https://docs.ncsa.illinois.edu/>`_; this will return keyword results from *all* of the NCSA user documentation sets.
 
 - If you're getting an error, perform a web search of the error message (Google, Bing, or others).
@@ -29,21 +28,21 @@ When you submit a support request, please let us know what you tried, and what h
 
 .. _general_support:
 
-General Resource Support - NCSA Support Help Center 
------------------------------------------------------
+General Resource Support
+---------------------------
 
-Use the `NCSA Support Help Center <http://help.ncsa.illinois.edu>`_ for all other issues, regardless of allocation type. Powered by Jira Service Manager (JSM), in this new tool you can:
+Use the `NCSA Help Portal <http://help.ncsa.illinois.edu>`_ for all other issues, regardless of allocation type. Powered by Jira Service Manager (JSM), in this new portal you can:
 
+- Submit support request tickets.
 - Search knowledge base articles to resolve common issues faster.
-- Submit help request tickets.
 - Monitor the status of your tickets.
 - Respond to NCSA staff as they work to resolve your tickets.
 
-Refer to the `JSM User Job Aid <https://docs.ncsa.illinois.edu/en/latest/_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the help center.
+Refer to the `JSM User Job Aid <https://docs.ncsa.illinois.edu/en/latest/_static/JSMUsersJobAid.pdf>`_ for information on how to navigate the portal.
 
 .. raw:: html
    
-   <p>The <a href="http://help.ncsa.illinois.edu">NCSA Support Help Center</a> is the preferred method to submit requests. However, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
+   <p>The <a href="http://help.ncsa.illinois.edu">NCSA Help Portal</a> is the preferred method to submit requests. However, if you run into problems using it, you can still email <a href="mailto:help@ncsa.illinois.edu?subject=Delta: ">help@ncsa.illinois.edu</a> for support. Expand the following section for guidelines on sending email requests so that NCSA staff can efficiently address them.</p>
 
 Email Support Request Guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/accounts.rst
+++ b/docs/source/user_guide/accounts.rst
@@ -13,7 +13,7 @@ Non-ACCESS project and account management, such as adding someone to a project, 
 Configuring Your Account
 ----------------------------
 
-Bash is the default shell. To change the default shell, :ref:`submit a support request <help>`.
+Bash is the default shell. To change the default shell, :ref:`submit a support request <general_support>`.
 
 Allocations
 -------------

--- a/docs/source/user_guide/citizenship.rst
+++ b/docs/source/user_guide/citizenship.rst
@@ -8,7 +8,7 @@ Here are some rules of thumb:
 
 -  Do not run production jobs on the login nodes (very short time debug tests are fine).
 -  Do not stress file systems with known-harmful access patterns (many thousands of small files in a single directory).
--  If you encounter an issue, :ref:`submit an informative support request <help>`; include the loaded modules (module list) and stdout/stderr messages in your email.
+-  If you encounter an issue, :ref:`submit an informative support request <general_support>`; include the loaded modules (module list) and stdout/stderr messages in your email.
 
 Acceptable Use Policies
 -------------------------

--- a/docs/source/user_guide/data_mgmt.rst
+++ b/docs/source/user_guide/data_mgmt.rst
@@ -34,7 +34,7 @@ For example, a user (with username: **auser**) who has an allocated project with
 Determine the mapping of ACCESS project to local project using the ``accounts`` command.
 
 Directory access changes can be made using the `facl <https://linux.die.net/man/1/setfacl>`_ command. 
-:ref:`Submit a support request <help>` if you need assistance enabling access for specific users and projects.
+:ref:`Submit a support request <general_support>` if you need assistance enabling access for specific users and projects.
 
 To avoid issues when file systems become unstable or non-responsive, do not put symbolic links from **$HOME** to the projects and scratch spaces.
 

--- a/docs/source/user_guide/job_accounting.rst
+++ b/docs/source/user_guide/job_accounting.rst
@@ -146,4 +146,4 @@ Refunds
 
 Refunds are considered, when appropriate, for jobs that failed due to circumstances beyond user control.
 
-To request a refund, :ref:`submit a support request <help>`. Please include the batch job IDs and the standard error and output files produced by the job(s).
+To request a refund, :ref:`submit a support request <general_support>`. Please include the batch job IDs and the standard error and output files produced by the job(s).

--- a/docs/source/user_guide/login.rst
+++ b/docs/source/user_guide/login.rst
@@ -19,7 +19,7 @@ Direct Access Login Nodes
 
 Direct access to the Delta login nodes is via SSH using your NCSA username, password, and NCSA Duo MFA. The login nodes provide access to the CPU and GPU resources on Delta. See the `NCSA Allocation and Account Management <https://wiki.ncsa.illinois.edu/display/USSPPRT/NCSA+Allocation+and+Account+Management>`_ page for links to NCSA Identity and NCSA Duo services. 
 
-**ACCESS awarded projects** - Your NCSA username is in your `ACCESS Profile <https://allocations.access-ci.org/profile>`_; once logged in, scroll to the bottom of the page to the "Resource Provider Site Usernames" table. If you don't know your NCSA username, :ref:`submit a support request <help>` for assistance.
+**ACCESS awarded projects** - Your NCSA username is in your `ACCESS Profile <https://allocations.access-ci.org/profile>`_; once logged in, scroll to the bottom of the page to the "Resource Provider Site Usernames" table. If you don't know your NCSA username, :ref:`submit a support request <general_support>` for assistance.
 
 Login Node Hostnames
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,7 +65,7 @@ In the examples below, replace ``username`` with your Delta login username.
 
 Use of SSH key pairs is disabled for general use.  This means that most individual users, even principal investigators (PIs), are **not allowed** to use SSH key pairs to log in instead of 2-factor authentication.  
 
-The one exception is: if you are the PI of a Gateway allocation (this is not most projects), then please :ref:`submit a support request <help>` to get the Gateway account's key pairs set up.  
+The one exception is: if you are the PI of a Gateway allocation (this is not most projects), then please :ref:`submit a support request <general_support>` to get the Gateway account's key pairs set up.  
 
 Maintaining Persistent Login Sessions: tmux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -72,7 +72,7 @@ Use ``module spider package_name`` to search for software in Lmod and see the st
 
 See also: `User Guide for Lmod <https://lmod.readthedocs.io/en/latest/010_user.html>`_.
 
-Please :ref:`submit a support request <help>` for help with software not currently installed on the Delta system. 
+Please :ref:`submit a support request <general_support>` for help with software not currently installed on the Delta system. 
 
 - For single user or single project use cases the preference is for the user to use the Spack software package manager to install software locally against the system Spack installation. 
   Delta support staff are available to provide limited assistance. 
@@ -82,7 +82,7 @@ Python
 ----------
 
 .. note::
-   When submitting :ref:`support requests <help>` for python, please provide the following and understand that Delta support staff time is a finite resource while python developments (new software and modules) are growing at nearly infinite velocity:
+   When submitting :ref:`support requests <general_support>` for python, please provide the following and understand that Delta support staff time is a finite resource while python developments (new software and modules) are growing at nearly infinite velocity:
 
    - Python version or environment used (describe fully, with the commands needed to reproduce)
    - Error output or log from what went wrong (screenshots are more difficult to work with than text data)
@@ -703,7 +703,7 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 Similar to the setup for anaconda_cpu, Delta has GPU versions of anaconda3 (``module load anaconda3_gpu``) and installed PyTorch and TensorFlow CUDA aware python modules into these versions. 
 You may use these modules when working with the GPU nodes. 
 See ``conda list`` after loading the module to review what is already installed. 
-As with anaconda3_cpu, :ref:`submit a support request <help>` if there are generally useful modules you would like installed for the broader community. 
+As with anaconda3_cpu, :ref:`submit a support request <general_support>` if there are generally useful modules you would like installed for the broader community. 
 A sample TensorFlow test script:
 
 .. code-block::


### PR DESCRIPTION
A few more 'help' updates related to the new JSM tool rollout:

- Updated the tool name to 'NCSA Help Portal' in the 'General Support' section in 'Getting Help'.
- Tweaked the wording in the 'this new tool can:' list to better align with the 'submit a support request' links throughout the docs. Also re-ordered the list so that submitting tickets is at the top.
- Updated the 'submit a support request' tags throughout the docs to link directly to the 'General Support' section.

- Unrelated to JSM rollout, also added wording to 'Explore Solutions' to direct users to the docs hub search box to search ALL of the docs. 
- Also unrelated to the JSM rollout, removed a redundant FAQ related to getting help.

RTD build: https://docs.ncsa.illinois.edu/systems/delta/en/proposed_changes/index.html