### PR TITLE
Clearer refs to /projects, /scratch, and quota command. Removed symlink-to-projects warning

### DIFF
--- a/docs/source/user_guide/data_mgmt.rst
+++ b/docs/source/user_guide/data_mgmt.rst
@@ -4,7 +4,7 @@ Data Management
 File Systems
 ----------------
 
-Each user has a home directory, **$HOME**, located at **/u/$USER**.
+Each user has a home directory, **$HOME**, located at **/u/$USER**. For each project they are assigned to, they will also have access to shared file space under /projects and /scratch.
 
 For example, a user (with username: **auser**) who has an allocated project with a local project serial code **abcd** will see the following entries in their $HOME and entries in the projects and scratch file systems.
 

--- a/docs/source/user_guide/data_mgmt.rst
+++ b/docs/source/user_guide/data_mgmt.rst
@@ -31,12 +31,10 @@ For example, a user (with username: **auser**) who has an allocated project with
    drwxrws---+ 2 buser delta_abcd 6 Feb 21 11:54 buser
    ...
 
-Determine the mapping of ACCESS project to local project using the ``accounts`` command.
+Determine the mapping of ACCESS project to local project using the ``accounts`` command. View your file system usage with the ``quota`` command.
 
 Directory access changes can be made using the `facl <https://linux.die.net/man/1/setfacl>`_ command. 
 :ref:`Submit a support request <general_support>` if you need assistance enabling access for specific users and projects.
-
-To avoid issues when file systems become unstable or non-responsive, do not put symbolic links from **$HOME** to the projects and scratch spaces.
 
 /tmp on Compute Nodes (Job Duration)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The first line of the File system section did not mention projects or scratch, which makes them less obvious to someone scanning the section. So I mentioned them.

I added a mention of the quota command.

I do not see the point of the docs saying "To avoid issues when file systems become unstable or non-responsive, do not put symbolic links from $HOME to the projects and scratch spaces." If I want to run my anaconda environment, or, in a recent case, launch COMSOL, I have to put .comsol somewhere outside of $HOME (because it is too big). If I do it with a symbolic link and projects or scratch is down, COMSOL won't run. If I instead put the directories in /projects and configure COMSOL to look there, it is still not going to run. Same with conda activate myenv. Seems like a pointless warning.