### PR TITLE
Remove jupyter tabs

### DIFF
--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -840,8 +840,8 @@ Jupyter Notebooks
 **Do not run Jupyter on the shared login nodes.**
 Instead, follow these steps to attach a Jupyter notebook running on a compute node to your local web browser:
 
-- Jump to: :ref:`jupyter-compute-node`
-- Jump to: :ref:`jupyter-compute-node-ngc`
+- :ref:`jupyter-compute-node`
+- :ref:`jupyter-compute-node-ngc`
 
 .. _jupyter-compute-node:
 

--- a/docs/source/user_guide/software.rst
+++ b/docs/source/user_guide/software.rst
@@ -840,202 +840,209 @@ Jupyter Notebooks
 **Do not run Jupyter on the shared login nodes.**
 Instead, follow these steps to attach a Jupyter notebook running on a compute node to your local web browser:
 
-.. tabs::
+- Jump to: :ref:`jupyter-compute-node`
+- Jump to: :ref:`jupyter-compute-node-ngc`
 
-   .. tab:: How to Run Jupyter on a Compute Node
+.. _jupyter-compute-node:
 
-      The Jupyter notebook executables are in your ``$PATH`` after loading the ``anaconda3`` module. If you run into problems from a previously saved Jupyter session (for example, you see paths where you do not have write permission), you may remove this file to get a fresh start: ``$HOME/.jupyter/lab/workspaces/default-*``. 
+How to Run Jupyter on a Compute Node
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      Follow these steps to run Jupyter on a compute node (CPU or GPU):
+The Jupyter notebook executables are in your ``$PATH`` after loading the ``anaconda3`` module. If you run into problems from a previously saved Jupyter session (for example, you see paths where you do not have write permission), you may remove this file to get a fresh start: ``$HOME/.jupyter/lab/workspaces/default-*``. 
 
-      #. On your local machine/laptop, open a terminal.
+Follow these steps to run Jupyter on a compute node (CPU or GPU):
 
-      #. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username).
+#. On your local machine/laptop, open a terminal.
 
-         .. code-block:: terminal
+#. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username).
 
-            ssh <my_delta_username>@login.delta.ncsa.illinois.edu
+   .. code-block:: terminal
 
-      #. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+      ssh <my_delta_username>@login.delta.ncsa.illinois.edu
 
-         .. warning::
-            If there is a conda environment active when you log into Delta, deactivate it before you continue. You will know you have an active conda environment if your terminal prompt has an environment name in parentheses prepended to it, like these examples:
+#. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
 
-            .. code-block::
+   .. warning::
+      If there is a conda environment active when you log into Delta, deactivate it before you continue. You will know you have an active conda environment if your terminal prompt has an environment name in parentheses prepended to it, like these examples:
 
-               (base) [<delta_username>@dt-login01 ~]$
+      .. code-block::
 
-               (mynewenv) [<delta_username>@dt-login01 ~]$
+         (base) [<delta_username>@dt-login01 ~]$
 
-            Run ``conda deactivate`` until there is no longer a name in parentheses prepended to your terminal prompt.  When you don't have any conda environment active, your prompt will look like this:
+         (mynewenv) [<delta_username>@dt-login01 ~]$
 
-            .. code-block::
+      Run ``conda deactivate`` until there is no longer a name in parentheses prepended to your terminal prompt.  When you don't have any conda environment active, your prompt will look like this:
 
-               [<delta_username>@dt-login01 ~]$
+      .. code-block::
 
-      #. Load the appropriate anaconda module. To see all of the available anaconda modules, run ``module avail anaconda``. This example uses ``anaconda3_cpu``. 
+         [<delta_username>@dt-login01 ~]$
 
-         .. code-block::
+#. Load the appropriate anaconda module. To see all of the available anaconda modules, run ``module avail anaconda``. This example uses ``anaconda3_cpu``. 
 
-            module load anaconda3_cpu
+   .. code-block::
 
-      #. Verify the module is loaded.
+      module load anaconda3_cpu
 
-         .. code-block::
+#. Verify the module is loaded.
 
-            module list
+   .. code-block::
 
-      #. Verify a jupyter-notebook is in your ``$PATH``.
+      module list
 
-         .. code-block::
+#. Verify a jupyter-notebook is in your ``$PATH``.
 
-            which jupyter-notebook
+   .. code-block::
 
-      #. Generate a ``MYPORT`` number and copy it to a notepad (you will use it in **steps 9 and 12**). 
+      which jupyter-notebook
 
-         .. code-block::
+#. Generate a ``MYPORT`` number and copy it to a notepad (you will use it in **steps 9 and 12**). 
 
-            MYPORT=$(($(($RANDOM % 10000))+49152)); echo $MYPORT
+   .. code-block::
 
-      #. Find the the ``account_name`` that you are going to use and copy it to a notepad (you will use it in **step 9**); your accounts are listed under ``Project`` when you run the ``accounts`` command.
+      MYPORT=$(($(($RANDOM % 10000))+49152)); echo $MYPORT
 
-         .. note::
-            To use a GPU node, you must pick a GPU account (the account name will end in "...-gpu").
+#. Find the the ``account_name`` that you are going to use and copy it to a notepad (you will use it in **step 9**); your accounts are listed under ``Project`` when you run the ``accounts`` command.
 
-         .. code-block::
+   .. note::
+      To use a GPU node, you must pick a GPU account (the account name will end in "...-gpu").
 
-            accounts
+   .. code-block::
 
-      #. Run the following ``srun`` command, with these replacements:
+      accounts
 
-         - Replace ``<account_name>`` with the account you are going to use, which you found and copied in **step 8**.
-         - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 7**.
-         - Modify the ``--partition``, ``--time``, and ``--mem`` options and/or add other options to meet your needs.
+#. Run the following ``srun`` command, with these replacements:
 
-         \
+   - Replace ``<account_name>`` with the account you are going to use, which you found and copied in **step 8**.
+   - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 7**.
+   - Modify the ``--partition``, ``--time``, and ``--mem`` options and/or add other options to meet your needs.
 
-         .. code-block::
+   \
 
-            srun --account=<account_name> --partition=cpu-interactive --time=00:30:00 --mem=32g jupyter-notebook --no-browser --port=<$MYPORT> --ip=0.0.0.0
+   .. code-block::
 
-      #. Copy the last 5 lines returned beginning with: **"To access the notebook, open this file in a browser..."** to a notepad (you will use this information **steps 12 and 14**). (It may take a few minutes for these lines to be returned.)
+      srun --account=<account_name> --partition=cpu-interactive --time=00:30:00 --mem=32g jupyter-notebook --no-browser --port=<$MYPORT> --ip=0.0.0.0
 
-         Note these two things about the URLs you copied:
+#. Copy the last 5 lines returned beginning with: **"To access the notebook, open this file in a browser..."** to a notepad (you will use this information **steps 12 and 14**). (It may take a few minutes for these lines to be returned.)
 
-         - The first URL begins with ``http://<cnXXX>.delta...``, ``<cnXXX>`` is the **internal hostname** and will be used in **step 12**.
-         - The second URL begins with ``http://127.0...``, you will use this entire URL in **step 14**.
+   Note these two things about the URLs you copied:
 
-         \
+   - The first URL begins with ``http://<cnXXX>.delta...``, ``<cnXXX>`` is the **internal hostname** and will be used in **step 12**.
+   - The second URL begins with ``http://127.0...``, you will use this entire URL in **step 14**.
 
-      #. Open a second terminal on your local machine/laptop.
+   \
 
-      #. Run the following ``ssh`` command, with these replacements: 
+#. Open a second terminal on your local machine/laptop.
 
-         - Replace ``<my_delta_username>`` with your Delta login username.
-         - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 7**.
-         - Replace ``<cn0XX>`` with internal hostname you copied in **step 10**.
+#. Run the following ``ssh`` command, with these replacements: 
 
-         \
+   - Replace ``<my_delta_username>`` with your Delta login username.
+   - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 7**.
+   - Replace ``<cn0XX>`` with internal hostname you copied in **step 10**.
 
-         .. code-block::
+   \
 
-            ssh -l <my_delta_username> -L 127.0.0.1:<$MYPORT>:<cn0XX>.delta.ncsa.illinois.edu:<$MYPORT> dt-login.delta.ncsa.illinois.edu
+   .. code-block::
 
-      #. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+      ssh -l <my_delta_username> -L 127.0.0.1:<$MYPORT>:<cn0XX>.delta.ncsa.illinois.edu:<$MYPORT> dt-login.delta.ncsa.illinois.edu
 
-      #. Copy and paste the entire **second URL** from **step 10** (begins with ``https://127.0...``) into your browser. You will be connected to the Jupyter instance running on your compute node of Delta.
+#. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
 
-         .. image:: images/software/jupyter_screenshot.jpg
-            :alt: Jupyter screenshot
-            :width: 700
+#. Copy and paste the entire **second URL** from **step 10** (begins with ``https://127.0...``) into your browser. You will be connected to the Jupyter instance running on your compute node of Delta.
 
-   .. tab:: How to Run Jupyter on a Compute Node, in an NGC Container
+   .. image:: images/software/jupyter_screenshot.jpg
+      :alt: Jupyter screenshot
+      :width: 700
 
-      Follow these steps to run Jupyter on a compute node, in an NGC container:
+.. _jupyter-compute-node-ngc:
 
-      #. On your local machine/laptop, open a terminal.
+How to Run Jupyter on a Compute Node, in an NGC Container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      #. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username.)
+Follow these steps to run Jupyter on a compute node, in an NGC container:
 
-         .. code-block:: terminal
+#. On your local machine/laptop, open a terminal.
 
-            ssh <my_delta_username>@login.delta.ncsa.illinois.edu
+#. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username.)
 
-      #. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+   .. code-block:: terminal
 
-      #. Generate a ``$MYPORT`` number and copy it to a notepad (you will use it in **steps 6, 8, and 14**). 
+      ssh <my_delta_username>@login.delta.ncsa.illinois.edu
 
-         .. code-block::
+#. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
 
-            MYPORT=$(($(($RANDOM % 10000))+49152)); echo $MYPORT
+#. Generate a ``$MYPORT`` number and copy it to a notepad (you will use it in **steps 6, 8, and 14**). 
 
-      #. Find the the ``account_name`` that you are going to use and copy it to a notepad (you will use it in **step 6**); your accounts are listed under ``Project`` when you run the ``accounts`` command. 
+   .. code-block::
 
-         .. note::
-            To use a GPU node, you must pick a GPU account (the account name will end in "...-gpu").
+      MYPORT=$(($(($RANDOM % 10000))+49152)); echo $MYPORT
 
-         .. code-block::
+#. Find the the ``account_name`` that you are going to use and copy it to a notepad (you will use it in **step 6**); your accounts are listed under ``Project`` when you run the ``accounts`` command. 
 
-            accounts
+   .. note::
+      To use a GPU node, you must pick a GPU account (the account name will end in "...-gpu").
 
-      #. Run the following ``srun`` command, with these replacements: 
+   .. code-block::
 
-         - Replace ``<account_name>`` with the account you are going to use, which you found and copied in step #5. 
-         - Replace ``<project_path>`` with the name of your projects folder (in two places).
-         - Replace ``<$MYPORT>`` with the ``MYPORT`` number you generated in **step 4**.
-         - Modify the ``--partition``, ``--time``, ``--mem``, and ``--gpus-per-node`` options and/or add other options to meet your needs.
+      accounts
 
-         \
+#. Run the following ``srun`` command, with these replacements: 
 
-         .. code-block::
+   - Replace ``<account_name>`` with the account you are going to use, which you found and copied in step #5. 
+   - Replace ``<project_path>`` with the name of your projects folder (in two places).
+   - Replace ``<$MYPORT>`` with the ``MYPORT`` number you generated in **step 4**.
+   - Modify the ``--partition``, ``--time``, ``--mem``, and ``--gpus-per-node`` options and/or add other options to meet your needs.
 
-            srun --account=<account_name> --partition=gpuA100x4-interactive --time=00:30:00 --mem=64g --gpus-per-node=1 apptainer run --nv --bind /projects/<project_path> /sw/external/NGC/pytorch:22.02-py3 jupyter-notebook --notebook-dir /projects/<project_path> --no-browser --port=<$MYPORT> --ip=0.0.0.0
+   \
 
-      #. Copy the last 2 lines returned (beginning with **"Or copy and paste this URL..."**) to a notepad. (It may take a few minutes for these lines to be returned.)
+   .. code-block::
 
-      #. Modify the URL you copied in **step 7** by changing ``hostname:8888`` to ``127.0.0.1:<$MYPORT>``. You will use the modified URL in **step 16**. (Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 4**.)
+      srun --account=<account_name> --partition=gpuA100x4-interactive --time=00:30:00 --mem=64g --gpus-per-node=1 apptainer run --nv --bind /projects/<project_path> /sw/external/NGC/pytorch:22.02-py3 jupyter-notebook --notebook-dir /projects/<project_path> --no-browser --port=<$MYPORT> --ip=0.0.0.0
 
-         \
+#. Copy the last 2 lines returned (beginning with **"Or copy and paste this URL..."**) to a notepad. (It may take a few minutes for these lines to be returned.)
 
-      #. Open a second terminal.
+#. Modify the URL you copied in **step 7** by changing ``hostname:8888`` to ``127.0.0.1:<$MYPORT>``. You will use the modified URL in **step 16**. (Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 4**.)
 
-      #. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username.)
+   \
 
-         .. code-block:: terminal
+#. Open a second terminal.
 
-            ssh <my_delta_username>@login.delta.ncsa.illinois.edu
+#. SSH into Delta. (Replace ``<my_delta_username>`` with your Delta login username.)
 
-      #. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+   .. code-block:: terminal
 
-      #. Find the **internal hostname** for your job and copy it to a notepad (you will use it in **step 14**).
+      ssh <my_delta_username>@login.delta.ncsa.illinois.edu
 
-         .. code-block::
+#. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
 
-            squeue -u $USER
+#. Find the **internal hostname** for your job and copy it to a notepad (you will use it in **step 14**).
 
-         The value returned under ``NODELIST`` is the internal hostname for your GPU job (``gpuaXXX``). You can now close this terminal.
+   .. code-block::
 
-      #. Open a third terminal.
+      squeue -u $USER
 
-      #. Run the following ``ssh`` command, with these replacements: 
+   The value returned under ``NODELIST`` is the internal hostname for your GPU job (``gpuaXXX``). You can now close this terminal.
 
-         - Replace ``<my_delta_username>`` with your Delta login username.
-         - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 4**.
-         - Replace ``<gpuaXXX>`` with internal hostname you copied in **step 12**.
+#. Open a third terminal.
 
-         \
+#. Run the following ``ssh`` command, with these replacements: 
 
-         .. code-block::
+   - Replace ``<my_delta_username>`` with your Delta login username.
+   - Replace ``<$MYPORT>`` with the ``$MYPORT`` number you generated in **step 4**.
+   - Replace ``<gpuaXXX>`` with internal hostname you copied in **step 12**.
 
-            ssh -l <my_delta_username> -L 127.0.0.1:<$MYPORT>:<gpuaXXX>.delta.internal.ncsa.edu:<$MYPORT> dt-login.delta.ncsa.illinois.edu
+   \
 
-      #. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+   .. code-block::
 
-      #. Copy and paste the entire **modified URL** (beginning with ``https://127.0...``) from **step 8** into your browser. You will be connected to the Jupyter instance running on your gpu node of Delta.
+      ssh -l <my_delta_username> -L 127.0.0.1:<$MYPORT>:<gpuaXXX>.delta.internal.ncsa.edu:<$MYPORT> dt-login.delta.ncsa.illinois.edu
 
-         .. image:: images/software/jupyter_screenshot.jpg
-            :alt: Jupyter screenshot
-            :width: 700
+#. Enter your **NCSA** password and complete the Duo MFA. Note, the terminal will not show your password (or placeholder symbols such as asterisks [*]) as you type.
+
+#. Copy and paste the entire **modified URL** (beginning with ``https://127.0...``) from **step 8** into your browser. You will be connected to the Jupyter instance running on your gpu node of Delta.
+
+   .. image:: images/software/jupyter_screenshot.jpg
+      :alt: Jupyter screenshot
+      :width: 700
 
 List of Installed Software (CPU & GPU)
 ---------------------------------------


### PR DESCRIPTION
Removes tabs for 'how to run jupyter on a compute node' and 'how to run jupyter on a compute node, in an NGC container' and replaces them with headings (with anchor links).

RTD build: https://docs.ncsa.illinois.edu/systems/delta/en/remove-jupyter-tabs/user_guide/software.html#jupyter-notebooks

@greghbauer , please review/approve.