### PR TITLE
adds pytorch mulit-node example script

### DIFF
--- a/docs/source/user_guide/prog_env.rst
+++ b/docs/source/user_guide/prog_env.rst
@@ -53,7 +53,8 @@ To build (compile and link) a MPI program in Fortran, C, and C++:
    |                                 |                                            |                                           |
    |                                 | .. code-block::                            | - **C++:** mpic++ myprog.cc               |
    |                                 |                                            |                                           |
-   |                                 |    intel openmpi                           |                                           |
+   |                                 |    intel openmpi                           | - link using mpi compilers for cuda codes |
+   |                                 |                                            |   compiled with nvc or nvc++              |
    +---------------------------------+--------------------------------------------+-------------------------------------------+
    | Cray MPICH (unsupported)        | .. code-block::                            |                                           |
    |                                 |                                            |                                           |

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -1004,13 +1004,13 @@ Hybrid (MPI + OpenMP or MPI+X) on CPU Nodes
    </details>
 |
 
-Pytorch Multi-Node
+PyTorch Multi-Node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. raw:: html
 
    <details>
-   <summary><a><b>Pytorch Multi-Node example script</b> <i>(click to expand/collapse)</i></a></summary>
+   <summary><a><b>PyTorch Multi-Node example script</b> <i>(click to expand/collapse)</i></a></summary>
 
 .. code-block::
 
@@ -1053,6 +1053,7 @@ Pytorch Multi-Node
 .. raw:: html
 
    </details>
+|
 
 Parametric / Array / HTC Jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -1010,7 +1010,7 @@ PyTorch Multi-Node
 .. raw:: html
 
    <details>
-   <summary><a><b>PyTorch Multi-Node example script</b> <i>(click to expand/collapse)</i></a></summary>
+   <summary><a><b>pytorch multi-node example script</b> <i>(click to expand/collapse)</i></a></summary>
 
 .. code-block::
 


### PR DESCRIPTION
Adds pytorch mulit-node example script in Running Jobs.
Also adds additional info to the MPI commands table in Programming Environment.

Galen made the changes and I reviewed them.