### PR TITLE
Attempt to correct :ref: visualization.rst

### DIFF
--- a/docs/source/user_guide/visualization.rst
+++ b/docs/source/user_guide/visualization.rst
@@ -135,7 +135,7 @@ VTK
 VTK Python API
 ~~~~~~~~~~~~~~~
 
-To use the VTK Python API, i.e. in order to ``import vtk``, just install with pip or conda following the guidance at :ref:`the Python documentation <python>`.
+To use the VTK Python API, i.e. in order to ``import vtk``, just install with pip or conda following the guidance at :ref:`Python <python>`.
 
 VTK C++ API
 ~~~~~~~~~~~


### PR DESCRIPTION
In the VTK Python API section, I would like to have a link to https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/software.html#python Based on the :ref:'s for OOD in the ParaView and VisIt sections, I made one that went to the official Python.org documentation?! 

IIUC, the text needs to be the exact header text, so I'm trying just that.