### PR TITLE
Added password reset info and updated MIG info

### DIFF
--- a/docs/source/user_guide/accounts.rst
+++ b/docs/source/user_guide/accounts.rst
@@ -10,6 +10,11 @@ ACCESS projects use the `ACCESS user portal <https://support.access-ci.org/>`_ f
 
 Non-ACCESS project and account management, such as adding someone to a project, is handled by NCSA group management tools. For more information, go to `Group/Project Member Management <https://docs.ncsa.illinois.edu/en/latest/account-mgmt/group-mgmt.html#group-mgmt>`_.
 
+Reset Your Password
+--------------------
+
+For instructions on how to reset the NCSA password that you use to log in to Delta, go to `Manage Your NCSA Identity - Reset Your Password <https://docs.ncsa.illinois.edu/en/latest/account-mgmt/identity-mgmt.html#reset-your-password>`_.
+
 Configuring Your Account
 ----------------------------
 

--- a/docs/source/user_guide/architecture.rst
+++ b/docs/source/user_guide/architecture.rst
@@ -5,15 +5,17 @@ Delta is designed to help applications transition from CPU-only to GPU or hybrid
 Delta has some important architectural features to facilitate new discovery and insight:
 
 -  A single processor architecture (AMD) across all node types: CPU and GPU
--  Support for NVIDIA A100 MIG GPU partitioning, allowing for fractional use of the A100s if your workload is not able to exploit an entire A100 efficiently
+-  A100 FP32 and FP64 support 
 -  Raytracing hardware support from the NVIDIA A40 GPUs
 -  Nine large memory (2 TB) nodes
 -  A low latency and high bandwidth HPE/Cray Slingshot interconnect between compute nodes
 -  Lustre for home, projects, and work file systems
 -  Support for relaxed and non-POSIX I/O (feature not yet implemented)
--  Shared-node jobs and the single core and single MIG GPU slice
+-  Shared-node jobs
 -  Resources for persistent services in support of Gateways, Open OnDemand, and Data Transport nodes
 -  Unique AMD MI100 resource
+
+**NOTE:** Delta A100 GPUs do NOT have MIG enabled.
 
 Model Compute Nodes
 ----------------------

--- a/docs/source/user_guide/running_jobs.rst
+++ b/docs/source/user_guide/running_jobs.rst
@@ -132,7 +132,7 @@ Job and Node Policies
 
      --exclusive --mem=0
 
-  GPU NVIDIA MIG (GPU slicing) for the A100 will be supported at a future date.
+  GPU NVIDIA MIG (GPU slicing) for the A100 is not supported at this time.
 
 .. _preempt:
 


### PR DESCRIPTION
Updated MIG info in architecture.rst and running_jobs.rst to reflect that it isn't supported.

Added a 'password reset' section to accounts.rst. This is to try to beat the Delta Science Gateway password reset page in SEO ranking if someone searches 'ncsa delta password reset'.